### PR TITLE
fix transparency issues and multiple imports of three.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var THREE = require('three');
+import * as THREE from 'three';
 var msgpack = require('msgpack-lite');
 var dat = require('dat.gui').default; // TODO: why is .default needed?
 import {mergeBufferGeometries} from 'three/examples/jsm/utils/BufferGeometryUtils.js';

--- a/test/meshfile_object_dae.html
+++ b/test/meshfile_object_dae.html
@@ -74,12 +74,6 @@ let dae_contents = `<?xml version="1.0" encoding="UTF-8"?>
                         <reflectivity>
                             <float>0.5</float>
                         </reflectivity>
-                        <transparent>
-                            <color>0 0 0 1</color>
-                        </transparent>
-                        <transparency>
-                            <float>0</float>
-                        </transparency>
                         <index_of_refraction>
                             <float>0</float>
                         </index_of_refraction>


### PR DESCRIPTION
Copying my reply to the rdeits/meshat PR:

Looking at it closer it seems as though the latest release is properly reading the Collada form in the `meshfile_object_date.html`.
There is a section in there setting the transparency:
```
                        <transparent>
                            <color>1 1 1 1</color>
                        </transparent>
                        <transparency>
                            <float>0</float>
                        </transparency>
```
Before it wasn't setting the object to transparent.  If you modify the `<float>0</float>` value to 0.5 or to 1 you can see the box now.  If you remove both the `<transparent>` and `<transparency>` tags it will show the box as well.

Looking at the three.js source code in this section: https://github.com/mrdoob/three.js/blob/4afef617be65dcd67a67cfbf1bd5cb1864cef50b/examples/jsm/loaders/ColladaLoader.js#L1709-L1740
Handles the transparency loading of the Collada file.
I believe that this PR is the cause of the change in behavior: https://github.com/mrdoob/three.js/pull/22679
It specifically updates so that having a transparency element will cause transparency to turn on and be set to 0.

Additionally, the other change from the `requires` to `import` prevents the error about multiple instances of three.js.